### PR TITLE
General upgrades to the repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,81 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Build release
+        run: nix develop -c make release
+
+      - name: Build debug
+        run: nix develop -c make clean && nix develop -c make debug
+
+      - name: Generate compile_commands.json
+        run: nix develop -c make clean && nix develop -c compiledb make release
+
+      - name: Upload compile_commands.json
+        uses: actions/upload-artifact@v4
+        with:
+          name: compile-commands
+          path: compile_commands.json
+          retention-days: 1
+
+  check:
+    name: Static Analysis
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Download compile_commands.json
+        uses: actions/download-artifact@v4
+        with:
+          name: compile-commands
+
+      - name: clang-format
+        run: |
+          nix develop -c bash -c '
+            find src -name "*.c" -o -name "*.h" | xargs clang-format --dry-run --Werror -style=file
+          '
+
+      - name: cppcheck
+        run: |
+          nix develop -c bash -c '
+            cppcheck --enable=warning,style,performance,portability \
+                     --suppress=missingIncludeSystem \
+                     --error-exitcode=1 \
+                     src/
+          '
+
+      - name: clang-tidy
+        run: |
+          nix develop -c bash -c '
+            find src -name "*.c" | xargs clang-tidy -p .
+          '
+
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Run unit tests
+        run: nix develop -c make test

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ build/**
 tests/report/*
 test/build/*
 
+# Log Files
+*.log
+
 # Archivos de IDEs - LSPs
 # -----------------------
 .idea

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,62 @@
+stages:
+  - build
+  - check
+  - test
+
+default:
+  image: nixos/nix
+  before_script:
+    # Enable flakes and nix-command in the container
+    - echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf
+
+# ---------------------------------------------------------------------------
+# Build Stage
+# ---------------------------------------------------------------------------
+build:
+  stage: build
+  script:
+    - nix develop -c make release
+    - nix develop -c make clean && nix develop -c make debug
+    - nix develop -c make clean && nix develop -c compiledb make release
+  artifacts:
+    paths:
+      - compile_commands.json
+    expire_in: 1 hour
+
+# ---------------------------------------------------------------------------
+# Check Stage
+# ---------------------------------------------------------------------------
+clang-format:
+  stage: check
+  needs:
+    - job: build
+      artifacts: false
+  script:
+    - nix develop -c bash -c 'find src -name "*.c" -o -name "*.h" | xargs clang-format --dry-run --Werror -style=file'
+
+cppcheck:
+  stage: check
+  needs:
+    - job: build
+      artifacts: false
+  script:
+    - nix develop -c bash -c 'cppcheck --enable=warning,style,performance,portability --suppress=missingIncludeSystem --error-exitcode=1 src/'
+
+clang-tidy:
+  stage: check
+  needs:
+    - job: build
+      artifacts: true
+  script:
+    - nix develop -c bash -c 'find src -name "*.c" | xargs clang-tidy -p .'
+
+# ---------------------------------------------------------------------------
+# Test Stage
+# ---------------------------------------------------------------------------
+unit-tests:
+  stage: test
+  needs:
+    - job: build
+      artifacts: false
+  script:
+    - nix develop -c make test

--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ ifeq (test,$(firstword $(MAKECMDGOALS)))
 
   TEST_ARG=$(strip $(firstword $(RUN_ARGS)))
   ifeq ($(TEST_ARG),)
-	TEST_ARG="runalltests"
+	TEST_ARG="all"
   endif
 
 endif

--- a/Readme.md
+++ b/Readme.md
@@ -5,13 +5,24 @@ and directory structure:
 
 ```
 .
-├── docs
-├── Makefile
-├── Readme.md
-├── src
+├── docs/
+├── src/
 │   └── main.c
-├── test
-└── tools
+├── templates/
+│   ├── module.c
+│   ├── module.h
+│   └── test_module.c
+├── test/
+│   ├── Makefile
+│   ├── project.yml
+│   └── tests/
+├── tools/
+├── .github/
+├── .gitlab-ci.yml
+├── .clang-format
+├── flake.nix
+├── Makefile
+└── Readme.md
 ```
 
 * **docs:** This directory would contain any documentation related to the
@@ -20,10 +31,13 @@ and directory structure:
 
 * **src:** This directory would hold the source code of the project.
 
+* **templates:** This directory holds the template files used by the module
+  generator to create new source, header, and test file stubs.
+
 * **test:** This directory would hold test files, including unit and functional
   tests, which can be run to ensure the program is working as intended. The
-  current version contains a project configuration file based on the ceedling
-  unit-tests suite for embedded C projects.
+  current version contains a project configuration file based on the Ceedling
+  v1.0.x unit-test framework for C projects.
 
 * **tools:** This directory would hold any build scripts or third-party tools
   used in the project.
@@ -32,20 +46,43 @@ and directory structure:
   It contains instructions to compile and link the source code, run tests, and
   generate executable files.
 
-* **Readme.md:** This file contains information about the repository, such as
-  usage instructions, installation instructions, project overview, and any
-  other relevant information.
-
 By modifying the Makefile configuration, this repository can now be utilized in
 both cross-compilation projects and native applications with ease.
 
-## Building and Running the Project
 
-Assuming you have make installed, you can build and run the project with the
-following commands:
+## Development Environment
+
+This project uses [Nix](https://nixos.org/) to provide a reproducible
+development environment. The `flake.nix` file declares all required
+dependencies, so all developers and CI pipelines use the exact same toolchain.
+
+To enter the development shell:
 
 ```
-make all
+nix develop
+```
+
+This repository can also be used as a Nix flake template to initialize new
+projects. The packages in `flake.nix` should be adjusted to match the
+toolchain required for each specific project, along with the tool definitions
+(`CXX`, `GDB`, etc.) in the `Makefile`.
+
+The following tools are provided by default:
+
+* **C Toolchain:** gcc, make, gdb, binutils
+* **Static Analysis:** clang-format, clang-tidy, cppcheck
+* **Unit Testing:** Ceedling v1.0.x (with CMock and Unity)
+* **Code Coverage:** gcovr
+* **Build Utilities:** compiledb
+
+
+## Building and Running the Project
+
+From inside the development shell (`nix develop`), you can build and run the
+project with the following commands:
+
+```
+make run
 ```
 
 This would compile the source code into an executable named after the name of
@@ -57,11 +94,55 @@ following command can be used (assuming the root dir of the repo is named
 build/cproj
 ```
 
+For a debug build with symbols and no optimizations:
 
-If you want to run the tests, use the following command:
+```
+make debug
+```
+
+For more info on the available `Make` targets:
+
+```
+make help
+```
+
+
+## Module Generator
+
+New source modules can be scaffolded using the module generator. Running the
+following command:
+
+```
+make module src/path/modulename
+```
+
+Will create:
+* `src/path/modulename.c` — source file
+* `src/path/modulename.h` — header file
+* `test/tests/path/test_modulename.c` — unit test file
+
+The generated files are populated from the templates in the `templates/`
+directory.
+
+
+## Testing
+
+Unit tests are managed using Ceedling v1.0.x. To run the full test suite:
 
 ```
 make test
+```
+
+To run tests for a specific source file:
+
+```
+make test src/path/modulename
+```
+
+To generate a coverage report:
+
+```
+make test coverage
 ```
 
 This would compile the test files and run them. Any output would be printed to

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771848320,
+        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,51 @@
+{
+  description = "C development environment for embedded and native projects";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            # C Toolchain
+            pkgs.gcc
+            pkgs.gnumake
+            pkgs.gdb
+            pkgs.binutils
+
+            # Static Analysis & Formatting
+            pkgs.clang-tools
+            pkgs.cppcheck
+
+            # Unit Testing (Ceedling + dependencies)
+            pkgs.ceedling
+
+            # Code Coverage
+            pkgs.gcovr
+          ];
+
+          shellHook = ''
+            echo "C Project Development Environment"
+            echo "=================================="
+            echo "Toolchain: GCC $(gcc --version | head -n1 | awk '{print $NF}')"
+            echo "Make:      $(make --version | head -n1)"
+            echo "Ceedling:  $(ceedling version 2>/dev/null || echo 'available')"
+            echo ""
+            echo "Run 'make help' for available targets"
+          '';
+        };
+      }
+    ) // {
+      templates.default = {
+        path = ./.;
+        description = "C development environment for embedded and native projects";
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,7 @@
             pkgs.gnumake
             pkgs.gdb
             pkgs.binutils
+            pkgs.compiledb
 
             # Static Analysis & Formatting
             pkgs.clang-tools

--- a/test/Makefile
+++ b/test/Makefile
@@ -19,6 +19,17 @@ TOOL = ceedling
 RM = rm -rf
 
 TOOLFLAGS ?=
+BUILD_PATH = build
+
+# Ceedling copies vendors Unity/CMock sources into the build directory. When
+# running from a Nix environment, the copied files inherit the read-only
+# permissions from the Nix store, causing permission errors on subsequent runs.
+# This macro wraps ceedling calls to fix vendor permissions after execution.
+define run-ceedling
+	$(TOOL) $(TOOLFLAGS) $(1); _rc=$$?; \
+	if [ -d $(BUILD_PATH)/vendor ]; then chmod -R u+w $(BUILD_PATH)/vendor; fi; \
+	exit $$_rc
+endef
 
 # ***************************************
 #
@@ -46,9 +57,9 @@ help:
 #
 clean:
 	@echo
-	@echo "Calling CEEDLING for cleanup"
+	@echo "Cleaning test build directories..."
 	@echo
-	$(TOOL) $(TOOLFLAGS) clobber
+	@if [ -d $(BUILD_PATH) ]; then chmod -R u+w $(BUILD_PATH) && $(RM) $(BUILD_PATH); fi
 	@echo
 	@echo "Done."
 	@echo
@@ -58,7 +69,7 @@ all:
 	@echo
 	@echo "Calling CEEDLING (all tests)"
 	@echo
-	$(TOOL) $(TOOLFLAGS) $(TEST_TARGET_OPTS) test:all
+	@$(call run-ceedling,$(TEST_TARGET_OPTS) test:all)
 	@echo
 	@echo "Done testing for target $(TARGET)."
 	@echo
@@ -67,7 +78,7 @@ coverage:
 	@echo
 	@echo "Calling CEEDLING to generate coverage information..."
 	@echo
-	$(TOOL) $(TOOLFLAGS) $(TEST_TARGET_OPTS) gcov:all report:gcov
+	@$(call run-ceedling,$(TEST_TARGET_OPTS) gcov:all report:gcov)
 	@echo
 	@echo "Done testing for target $(TARGET)."
 	@echo
@@ -78,13 +89,13 @@ report: coverage
 # General test running rule for individual files
 #
 test_%.c %.c %::build-info
-	$(TOOL) $(TOOLFLAGS) $(TEST_TARGET_OPTS) test:$(@:test_%=%)
+	@$(call run-ceedling,$(TEST_TARGET_OPTS) test:$(@:test_%=%))
 
 #
 # General coverage generation rule for individual files
 #
 cov_%.c cov_%::build-info
-	$(TOOL) $(TOOLFLAGS) $(TEST_TARGET_OPTS) gcov:$(@:cov_%=%) report:gcov | grep -v "Could not find"
+	@$(call run-ceedling,$(TEST_TARGET_OPTS) gcov:$(@:cov_%=%) report:gcov) | grep -v "Could not find"
 
 #
 # Print the actual coverage report
@@ -97,4 +108,4 @@ summary:
 #
 Makefile: ;
 
-.PHONY: clean all delta report coverage summary help
+.PHONY: clean all report coverage summary help

--- a/test/Makefile
+++ b/test/Makefile
@@ -32,10 +32,9 @@ help:
 	@echo "UNIT-TEST MAKEFILE:"
 	@echo "----------------------------------------------"
 	@echo
-	@echo TARGETS DE TESTING:
+	@echo TESTING TARGETS:
 	@echo "clean         : Cleanup the test build directories"
 	@echo "all           : Run the whole test suite"
-	@echo "delta         : Only run the tests of modified source files"
 	@echo "report        : Generate a coverage report"
 	@echo "summary       : Print coverage summary"
 	@echo "<source-file> : Run the tests asosciated with the given source file"
@@ -64,20 +63,11 @@ all:
 	@echo "Done testing for target $(TARGET)."
 	@echo
 
-delta:
-	@echo
-	@echo "Calling CEEDLING (delta test)"
-	@echo
-	$(TOOL) $(TOOLFLAGS) $(TEST_TARGET_OPTS) test:delta
-	@echo
-	@echo "Done testing for target $(TARGET)."
-	@echo
-
 coverage:
 	@echo
 	@echo "Calling CEEDLING to generate coverage information..."
 	@echo
-	$(TOOL) $(TOOLFLAGS) $(TEST_TARGET_OPTS) gcov:all utils:gcov
+	$(TOOL) $(TOOLFLAGS) $(TEST_TARGET_OPTS) gcov:all report:gcov
 	@echo
 	@echo "Done testing for target $(TARGET)."
 	@echo
@@ -94,13 +84,13 @@ test_%.c %.c %::build-info
 # General coverage generation rule for individual files
 #
 cov_%.c cov_%::build-info
-	$(TOOL) $(TOOLFLAGS) $(TEST_TARGET_OPTS) gcov:$(@:cov_%=%) utils:gcov | grep -v "Could not find"
+	$(TOOL) $(TOOLFLAGS) $(TEST_TARGET_OPTS) gcov:$(@:cov_%=%) report:gcov | grep -v "Could not find"
 
 #
 # Print the actual coverage report
 #
 summary:
-	gcovr --root ../src --exclude ".*/test_.*" build/gcov/out --print-summary
+	gcovr --root ../src --exclude ".*/test_.*" build/artifacts/gcov/gcovr --print-summary
 
 #
 # Empty rule to avoid running test_% on the actual Makefile

--- a/test/project.yml
+++ b/test/project.yml
@@ -1,9 +1,10 @@
 #    Project: C-Proj
 #       file: project.yml
 #     author: germansc
-#    version: 1.0
+#    version: 2.0
 #
 #  Project configuration file for the unit-test framework based on Ceedling.
+#  Updated for Ceedling v1.0.x
 #
 #  Copyright (c) 2023 germansc. All Rights Reserved.
 #
@@ -11,13 +12,10 @@
 
 :project:
   :use_exceptions: FALSE
-  :use_test_preprocessor: TRUE
-  :use_auxiliary_dependencies: TRUE
+  :use_test_preprocessor: :all
   :build_root: build
 #  :release_build: TRUE
   :test_file_prefix: test_
-  :which_ceedling: gem
-  :ceedling_version: 0.31.1
   :default_tasks:
     - test:all
 
@@ -32,6 +30,8 @@
     - -:tests/support
   :source:
     - ../src/**
+  :include:
+    - ../src/**
   :support:
     - tests/support
   :libraries: []
@@ -42,11 +42,9 @@
   #  2) add entries to the :common: section (e.g. :test: has TEST defined)
   :common: &common_defines []
   :test:
-    - *common_defines
-    - TEST
-  :test_preprocess:
-    - *common_defines
-    - TEST
+    :*:
+      - *common_defines
+      - TEST
 
 :cmock:
   :mock_prefix: mock_
@@ -66,6 +64,10 @@
 # You will need to have gcov and gcovr both installed to make it work.
 # For more information on these options, see docs in plugins/gcov
 :gcov:
+  :summaries: TRUE
+  :report_task: TRUE
+  :utilities:
+    - gcovr
   :reports:
     - HtmlDetailed
   :gcovr:
@@ -90,9 +92,7 @@
   :release: []
 
 :plugins:
-  :load_paths:
-    - "#{Ceedling.load_path}"
   :enabled:
-    - stdout_pretty_tests_report
+    - report_tests_pretty_stdout
     - module_generator
 ...

--- a/test/project.yml
+++ b/test/project.yml
@@ -95,4 +95,5 @@
   :enabled:
     - report_tests_pretty_stdout
     - module_generator
+    - gcov
 ...


### PR DESCRIPTION
Kind of a messy PR, but the following features were added:
- Flake based environment definition: Added a flake.nix based setup that allows the repo to be used as a flake template. Defined a basic dev environment with the required tools.
- Updated ceedling config for v1.0.1: Updated the project config and the related makefile targets for the new main release of ceedling. Some specific hacks were included specifics to ceedling in a nix  environment, since some vendor files that are copied to the build output inhering read-only permission that block further ceedling calls.
- Added CI configuration for both Github and Gitlab based repos. Three core stages/jobs are defined for Building, Checking and Testing the project. All jobs work on the dev environment defined by the flake.
 